### PR TITLE
Minor improvements in links

### DIFF
--- a/packages/yx_scope/README.md
+++ b/packages/yx_scope/README.md
@@ -105,4 +105,4 @@ Due to null-safety, `ScopeHolder` provides a compile-safe check for the existenc
 directly
 at the time of writing code, not at runtime.
 
-![Scope Anatomy](doc/assets/scope_anatomy.png)
+![Scope Anatomy](https://raw.githubusercontent.com/yandex/yx_scope/refs/heads/main/packages/yx_scope/doc/assets/scope_anatomy.png)

--- a/packages/yx_scope/pubspec.yaml
+++ b/packages/yx_scope/pubspec.yaml
@@ -1,7 +1,7 @@
 name: yx_scope
 description: Scope management for dependencies
 version: 1.0.0
-repository: 'https://github.com/yandex/yx_scope/packages/yx_scope'
+repository: 'https://github.com/yandex/yx_scope/tree/main/packages/yx_scope'
 publish_to: 'none'
 
 environment:

--- a/packages/yx_scope_flutter/pubspec.yaml
+++ b/packages/yx_scope_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: yx_scope_flutter
 description: Package to use yx_scope with flutter
 version: 1.0.0
-repository: 'https://github.com/yandex/yx_scope/packages/yx_scope_flutter'
+repository: 'https://github.com/yandex/yx_scope/tree/main/packages/yx_scope_flutter'
 publish_to: 'none'
 
 environment:

--- a/packages/yx_scope_linter/pubspec.yaml
+++ b/packages/yx_scope_linter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: yx_scope_linter
 description: Lint rules for yx_scope
 version: 0.1.0
-repository: 'https://github.com/yandex/yx_scope/packages/yx_scope_linter'
+repository: 'https://github.com/yandex/yx_scope/tree/main/packages/yx_scope_linter'
 publish_to: 'none'
 
 environment:


### PR DESCRIPTION
Saw a couple of things when I opened the page in pub.dev, here are the fixes:

- Images must have a full path to the source. Relative paths are not supported and images will not be displayed in README.md. Changed to the full path to `githubusercontent`.
- Links of packages to their repositories in GitHub were invalid due to their structure. Just correct them.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en