### PR TITLE
Corrects inheritance of DataScopeContainer class to BaseScopeContainer

### DIFF
--- a/packages/yx_scope/lib/src/scope_container.dart
+++ b/packages/yx_scope/lib/src/scope_container.dart
@@ -22,7 +22,7 @@ abstract class ChildScopeContainer<Parent extends Scope>
 }
 
 /// {@macro data_scope_container}
-abstract class DataScopeContainer<Data> extends ScopeContainer
+abstract class DataScopeContainer<Data> extends BaseScopeContainer
     with DataScopeContainerMixin<Data> {
   DataScopeContainer({
     required Data data,


### PR DESCRIPTION
Заметил, что в DataScopeContainer неправильное наследование, из-за этого, если использовать в initializeQueue геттер data, то в контроллере ScopeContainer будет выкидываться исключение, так как порядок вызовов будет такой:

_initializeQueueNoDuplications
this.data = data;
_initializeQueueNoDuplications

Получается, что функция _initializeQueueNoDuplications будет вызвана дважды, ну и состояние будет неправильное.