### PR TITLE
Prohibit DataScope initialization with null data by enforcing non-nullable Data type

### DIFF
--- a/packages/yx_scope/lib/src/base_scope_container.dart
+++ b/packages/yx_scope/lib/src/base_scope_container.dart
@@ -206,7 +206,7 @@ mixin ChildScopeContainerMixin<Parent extends Scope> on BaseScopeContainer {
 /// If the scope has data, you can access
 /// it as a non-nullable value within current scope.
 /// {@endtemplate}
-mixin DataScopeContainerMixin<Data> on BaseScopeContainer {
+mixin DataScopeContainerMixin<Data extends Object> on BaseScopeContainer {
   Data? _data;
 
   /// Must not be used anyone except for the child with this mixin.

--- a/packages/yx_scope/lib/src/scope_container.dart
+++ b/packages/yx_scope/lib/src/scope_container.dart
@@ -22,8 +22,8 @@ abstract class ChildScopeContainer<Parent extends Scope>
 }
 
 /// {@macro data_scope_container}
-abstract class DataScopeContainer<Data> extends BaseScopeContainer
-    with DataScopeContainerMixin<Data> {
+abstract class DataScopeContainer<Data extends Object>
+    extends BaseScopeContainer with DataScopeContainerMixin<Data> {
   DataScopeContainer({
     required Data data,
     String? name,
@@ -40,8 +40,8 @@ abstract class DataScopeContainer<Data> extends BaseScopeContainer
 ///
 /// [DataScopeContainer]:
 /// {@macro data_scope_container}
-abstract class ChildDataScopeContainer<Parent extends Scope, Data>
-    extends BaseScopeContainer
+abstract class ChildDataScopeContainer<Parent extends Scope,
+        Data extends Object> extends BaseScopeContainer
     with ChildScopeContainerMixin<Parent>, DataScopeContainerMixin<Data> {
   ChildDataScopeContainer({
     required Parent parent,

--- a/packages/yx_scope/lib/src/scope_holder.dart
+++ b/packages/yx_scope/lib/src/scope_holder.dart
@@ -122,7 +122,8 @@ abstract class ChildScopeHolder<Container extends ChildScopeContainer<Parent>,
 ///
 /// If you need to differentiate [BaseScopeContainer] and it's abstract interface
 /// then you better use [BaseDataScopeHolder] directly.
-abstract class DataScopeHolder<Container extends DataScopeContainer<Data>, Data>
+abstract class DataScopeHolder<Container extends DataScopeContainer<Data>,
+        Data extends Object>
     extends BaseDataScopeHolder<Container, Container, Data> {
   DataScopeHolder({
     List<ScopeListener>? scopeListeners,
@@ -168,9 +169,10 @@ abstract class DataScopeHolder<Container extends DataScopeContainer<Data>, Data>
 /// If you need to differentiate [BaseScopeContainer] and it's abstract interface
 /// then you better use [BaseChildDataScopeHolder] directly.
 abstract class ChildDataScopeHolder<
-    Container extends ChildDataScopeContainer<Parent, Data>,
-    Parent extends Scope,
-    Data> extends BaseChildDataScopeHolder<Container, Container, Parent, Data> {
+        Container extends ChildDataScopeContainer<Parent, Data>,
+        Parent extends Scope,
+        Data extends Object>
+    extends BaseChildDataScopeHolder<Container, Container, Parent, Data> {
   ChildDataScopeHolder(
     Parent parent, {
     List<ScopeListener>? scopeListeners,
@@ -256,7 +258,7 @@ abstract class BaseChildScopeHolder<
 abstract class BaseDataScopeHolder<
         Scope,
         Container extends DataScopeContainer<Data>,
-        Data> extends CoreScopeHolder<Scope, Container>
+        Data extends Object> extends CoreScopeHolder<Scope, Container>
     with _BaseDataScopeHolderMixin<Scope, Container, Data> {
   BaseDataScopeHolder({
     List<ScopeListener>? scopeListeners,
@@ -289,7 +291,7 @@ abstract class BaseChildDataScopeHolder<
         ScopeType,
         Container extends ChildDataScopeContainer<Parent, Data>,
         Parent extends Scope,
-        Data> extends CoreScopeHolder<ScopeType, Container>
+        Data extends Object> extends CoreScopeHolder<ScopeType, Container>
     with
         _BaseChildScopeHolderMixin<ScopeType, Container, Parent>,
         _BaseDataScopeHolderMixin<ScopeType, Container, Data> {
@@ -363,4 +365,4 @@ mixin _BaseChildScopeHolderMixin<
 mixin _BaseDataScopeHolderMixin<
     Scope,
     Container extends DataScopeContainerMixin<Data>,
-    Data> on CoreScopeHolder<Scope, Container> {}
+    Data extends Object> on CoreScopeHolder<Scope, Container> {}


### PR DESCRIPTION
#### Problem
It is currently not possible to initialize a `DataScope` with null data. For example:
```dart
class SomeScope extends DataScopeContainer<Id?>{}
```
Initializing the scope with null data results in a runtime error:
```
You must set data in your Scope constructor
```

#### Solution
To resolve this issue, we will enforce that `DataScope` cannot be initialized with null data by changing the generic type `Data` to `<Data extends Object>`. This ensures that `Data` is always non-nullable.

#### Changes
- Updated `DataScopeContainer`, `ChildDataScopeContainer`, `DataScopeHolder`, and `ChildDataScopeHolder` to use `<Data extends Object>` instead of `<Data>`.
- Modified relevant mixins and base classes to reflect this change.

This change will prevent runtime errors related to null data in `DataScope` and enforce non-nullable data at compile time.

---

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru