### PR TITLE
mounted check added to _subscribe

### DIFF
--- a/packages/yx_scope_flutter/lib/src/scope_listener.dart
+++ b/packages/yx_scope_flutter/lib/src/scope_listener.dart
@@ -94,9 +94,14 @@ class ScopeListenerState<T> extends State<ScopeListener<T>> {
   }
 
   void _subscribe() {
-    widget.listener(context, _holder.scope);
-    _removeStateListener =
-        _holder.listen((scope) => widget.listener(context, scope));
+    if (mounted) {
+      widget.listener(context, _holder.scope);
+      _removeStateListener = _holder.listen((scope) {
+        if (mounted) {
+          widget.listener(context, scope);
+        }
+      });
+    }
   }
 
   void _unsubscribe() {


### PR DESCRIPTION
The `_subscribe` method might be called after listener was already disposed because we call `_subscribe` method using `WidgetsBinding.instance.addPostFrameCallback`
So mounted check prevents us from getting errors like:
`Unhandled Exception: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).` (might be thrown when we access context in `_subscribe` method)
and
`Null check operator used on a null value.` (might be thrown when we access widget in `_subscribe` method)

Second mounted check added for code readability