### PR TITLE
Add test for checking rebuilds only for dependent widgets

### DIFF
--- a/packages/yx_scope_flutter/test/scope_builder_test.dart
+++ b/packages/yx_scope_flutter/test/scope_builder_test.dart
@@ -3,11 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:yx_scope/yx_scope.dart' as yx_scope;
 import 'package:yx_scope_flutter/yx_scope_flutter.dart';
 
-class CounterProvider {
-  int count;
-
-  CounterProvider(this.count);
-}
+import 'test_utils.dart';
 
 class AppScopeContainer extends yx_scope.ScopeContainer {
   late final counterProviderDep = dep(() => CounterProvider(0));

--- a/packages/yx_scope_flutter/test/test_utils.dart
+++ b/packages/yx_scope_flutter/test/test_utils.dart
@@ -1,0 +1,5 @@
+class CounterProvider {
+  int count;
+
+  CounterProvider(this.count);
+}


### PR DESCRIPTION
A simple test for rebuilding only scope-dependent widgets and not any widget in a ScopeProvider subtree.

---
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru