### PR TITLE
Checks for 3.35.7 and 3.38.4

### DIFF
--- a/.github/workflows/yx_scope_pr.yaml
+++ b/.github/workflows/yx_scope_pr.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Check the library against the most recent version and the previous minor version
+        # Check the packages against the most recent previous minor version
         flutter-version: [3.38.4, 3.35.7, 3.32.8, 3.29.3, 3.27.3, 3.24.5]
         package:
           - yx_scope/packages/yx_scope
@@ -56,8 +56,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Check the library against the most recent version and the previous minor version
-        flutter-version: [3.38.4, 3.35.7, 3.32.8, 3.29.3, 3.27.3]
+        # Check the linter against the most recent previous minor version
+        dart-version: [3.6.2, 3.7.2, 3.8.1, 3.9.2, 3.10.4]
 
     defaults:
       run:
@@ -68,19 +68,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+      - name: Set up Dart SDK
+        uses: dart-lang/setup-dart@v1
         with:
-          flutter-version: ${{ matrix.flutter-version }}
+          dart-version: ${{ matrix.dart-version }}
 
       - name: Install dependencies
-        run: flutter pub get
+        run: dart pub get
 
       - name: Check formatting
         run: dart format --set-exit-if-changed .
 
       - name: Run linter
-        run: flutter analyze
+        run: dart analyze
 
       - name: Verify custom_lint
         working-directory: yx_scope/packages/yx_scope_linter/example

--- a/.github/workflows/yx_scope_pr.yaml
+++ b/.github/workflows/yx_scope_pr.yaml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         # Check the library against the most recent version and the previous minor version
-        flutter-version: [3.38.4, 3.35.7, 3.32.8, 3.29.3, 3.27.3, 3.24.5]
+        flutter-version: [3.38.4, 3.35.7, 3.32.8, 3.29.3, 3.27.3]
 
     defaults:
       run:

--- a/.github/workflows/yx_scope_pr.yaml
+++ b/.github/workflows/yx_scope_pr.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         # Check the library against the most recent version and the previous minor version
         flutter-version: [3.38.4, 3.35.7, 3.32.8, 3.29.3, 3.27.3, 3.24.5]

--- a/.github/workflows/yx_scope_pr.yaml
+++ b/.github/workflows/yx_scope_pr.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Check the library against the most recent version and the previous minor version
-        flutter-version: [3.32.4, 3.29.2, 3.27.1, 3.24.5]
+        flutter-version: [3.38.4, 3.35.7, 3.32.8, 3.29.3, 3.27.3, 3.24.5]
         package:
           - yx_scope/packages/yx_scope
           - yx_scope/packages/yx_scope_flutter

--- a/.github/workflows/yx_scope_pr.yaml
+++ b/.github/workflows/yx_scope_pr.yaml
@@ -22,7 +22,6 @@ jobs:
         package:
           - yx_scope/packages/yx_scope
           - yx_scope/packages/yx_scope_flutter
-          - yx_scope/packages/yx_scope_linter
 
     defaults:
       run:
@@ -47,10 +46,42 @@ jobs:
       - name: Run linter
         run: flutter analyze
 
+      - name: Run tests
+        run: flutter test
+
+  ci_checks_linter:
+    name: CI Checks (Linter)
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Check the library against the most recent version and the previous minor version
+        flutter-version: [3.38.4, 3.35.7, 3.32.8, 3.29.3, 3.27.3, 3.24.5]
+
+    defaults:
+      run:
+        working-directory: yx_scope/packages/yx_scope_linter
+        shell: bash
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.flutter-version }}
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Check formatting
+        run: dart format --set-exit-if-changed .
+
+      - name: Run linter
+        run: flutter analyze
+
       - name: Verify custom_lint
         working-directory: yx_scope/packages/yx_scope_linter/example
         run: dart run custom_lint --watch
-
-      - name: Run tests
-        if: matrix.package != 'yx_scope/packages/yx_scope_linter'
-        run: flutter test

--- a/yx_scope/packages/yx_scope/analysis_options.yaml
+++ b/yx_scope/packages/yx_scope/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    avoid_types_as_parameter_names: false

--- a/yx_scope/packages/yx_scope_flutter/example/pubspec.yaml
+++ b/yx_scope/packages/yx_scope_flutter/example/pubspec.yaml
@@ -18,8 +18,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-  custom_lint: ^0.6.8
-  yx_scope_linter: ^0.1.0
+  custom_lint: ^0.7.0
+  yx_scope_linter: ^0.2.0
 
 flutter:
   uses-material-design: true

--- a/yx_scope/packages/yx_scope_linter/CHANGELOG.md
+++ b/yx_scope/packages/yx_scope_linter/CHANGELOG.md
@@ -4,6 +4,7 @@
 * custom_lint_builder ^0.6.2 -> ^0.7.0;
 * analyzer_plugin ^0.11.2 -> ^0.13.4;
 * analyzer ^6.4.1 -> ^7.0.0
+* min Dart version 2.27.0 -> 3.6.0
 
 ## 0.1.4 - 2025.07.08
 

--- a/yx_scope/packages/yx_scope_linter/CHANGELOG.md
+++ b/yx_scope/packages/yx_scope_linter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.0 - 2025.12.16
+
+* custom_lint ^0.6.8 -> ^0.7.0;
+* custom_lint_builder ^0.6.2 -> ^0.7.0;
+* analyzer_plugin ^0.11.2 -> ^0.13.4;
+* analyzer ^6.4.1 -> ^7.0.0
+
 ## 0.1.4 - 2025.07.08
 
 * Documentation links fixed

--- a/yx_scope/packages/yx_scope_linter/analysis_options.yaml
+++ b/yx_scope/packages/yx_scope_linter/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:lints/recommended.yaml
+
+analyzer:
+  errors:
+    deprecated_member_use: ignore

--- a/yx_scope/packages/yx_scope_linter/example/pubspec.yaml
+++ b/yx_scope/packages/yx_scope_linter/example/pubspec.yaml
@@ -11,6 +11,6 @@ dependencies:
 
 dev_dependencies:
   lints: ^2.0.0
-  custom_lint: ^0.6.8
+  custom_lint: ^0.7.0
   yx_scope_linter:
     path: ..

--- a/yx_scope/packages/yx_scope_linter/pubspec.yaml
+++ b/yx_scope/packages/yx_scope_linter/pubspec.yaml
@@ -13,11 +13,11 @@ environment:
   sdk: '>=2.19.6 <4.0.0'
 
 dependencies:
-  analyzer: ^7.0.0
-  analyzer_plugin: ^0.13.4
-  custom_lint_builder: ^0.7.0
+  analyzer: '>=6.4.1 <8.0.0'
+  analyzer_plugin: '>=0.11.2 <0.14.0'
+  custom_lint_builder: '>=0.6.2 <0.8.0'
   yx_scope: ^1.1.1
 
 dev_dependencies:
   lints: ^2.0.0
-  custom_lint: ^0.7.0
+  custom_lint: '>=0.6.8 <0.8.0'

--- a/yx_scope/packages/yx_scope_linter/pubspec.yaml
+++ b/yx_scope/packages/yx_scope_linter/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - dependency-management
 
 environment:
-  sdk: '>=2.19.6 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   analyzer: '>=6.4.1 <8.0.0'
@@ -20,4 +20,5 @@ dependencies:
 
 dev_dependencies:
   lints: ^2.0.0
+  # TODO: migrate to analysis_server_plugin — https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server_plugin/doc/writing_a_plugin.md
   custom_lint: '>=0.6.8 <0.8.0'

--- a/yx_scope/packages/yx_scope_linter/pubspec.yaml
+++ b/yx_scope/packages/yx_scope_linter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yx_scope_linter
 description: A package that contains static analysis rules for yx_scope DI framework
-version: 0.1.4
+version: 0.2.0
 repository: https://github.com/yandex/city-services-pub/tree/main/yx_scope/packages/yx_scope_linter
 issue_tracker: https://github.com/yandex/city-services-pub/issues
 topics:
@@ -13,10 +13,11 @@ environment:
   sdk: '>=2.19.6 <4.0.0'
 
 dependencies:
-  analyzer: ^6.4.1
-  analyzer_plugin: ^0.11.2
-  custom_lint_builder: ^0.6.2
+  analyzer: ^7.0.0
+  analyzer_plugin: ^0.13.4
+  custom_lint_builder: ^0.7.0
   yx_scope: ^1.1.1
 
 dev_dependencies:
   lints: ^2.0.0
+  custom_lint: ^0.7.0


### PR DESCRIPTION
1. Add CI checks for Flutter version 3.35.7 and 3.38.4
2. Update yx_scope_linter dependencies, min Dart SDK — 3.6.0
3. Ignore `avoid_types_as_parameter_names` for yx_scope

---
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru